### PR TITLE
correcting examples to remove tempfiles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sfarrow
 Title: Read/Write Simple Feature Objects ('sf') with 'Apache' 'Arrow'
-Version: 0.4.0
-Date: 2021-06-17
+Version: 0.4.1
+Date: 2021-10-25
 Authors@R: 
     person(given = "Chris",
            family = "Jochem",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# sfarrow 0.4.1
+
+* Cleaning examples to remove reverse dependency check errors in `arrow`
+(reported by @jonkeane).
+
 # sfarrow 0.4.0
 
 * New `find_geom` parameter in `read_sf_dataset()` adds any geometry columns to

--- a/R/st_arrow.R
+++ b/R/st_arrow.R
@@ -259,13 +259,19 @@ st_read_feather <- function(dsn, col_select = NULL, ...){
 #' @seealso \code{\link[arrow]{write_parquet}}
 #'
 #' @examples
+#' # read spatial object
 #' nc <- sf::st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
 #'
-#' st_write_parquet(obj=nc, dsn=file.path(tempdir(), "nc.parquet"))
+#' # create temp file
+#' tf <- tempfile(fileext = '.parquet')
+#' on.exit(unlink(tf))
+#'
+#' # write out object
+#' st_write_parquet(obj = nc, dsn = tf)
 #'
 #' # In Python, read the new file with geopandas.read_parquet(...)
-#'
-#' nc_p <- st_read_parquet(file.path(tempdir(), "nc.parquet"))
+#' # read back into R
+#' nc_p <- st_read_parquet(tf)
 #'
 #' @export
 st_write_parquet <- function(obj, dsn, ...){
@@ -305,13 +311,19 @@ st_write_parquet <- function(obj, dsn, ...){
 #' @seealso \code{\link[arrow]{write_feather}}
 #'
 #' @examples
+#' # read spatial object
 #' nc <- sf::st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
 #'
-#' st_write_feather(obj=nc, dsn=file.path(tempdir(), "nc.feather"))
+#' # create temp file
+#' tf <- tempfile(fileext = '.feather')
+#' on.exit(unlink(tf))
+#'
+#' # write out object
+#' st_write_feather(obj = nc, dsn = tf)
 #'
 #' # In Python, read the new file with geopandas.read_feather(...)
-#'
-#' nc_f <- st_read_feather(file.path(tempdir(), "nc.feather"))
+#' # read back into R
+#' nc_f <- st_read_feather(tf)
 #'
 #' @export
 st_write_feather <- function(obj, dsn, ...){
@@ -368,13 +380,15 @@ st_write_feather <- function(obj, dsn, ...){
 #' nc_g <- dplyr::group_by(nc, group)
 #'
 #' # write out to parquet datasets
+#' tf <- tempfile()  # create temporary location
+#' on.exit(unlink(tf))
 #' # partitioning determined by dplyr 'group_vars'
-#' write_sf_dataset(nc_g, path = file.path(tempdir(), "ds"))
+#' write_sf_dataset(nc_g, path = tf)
 #'
-#' list.files(file.path(tempdir(), "ds"), recursive = TRUE)
+#' list.files(tf, recursive = TRUE)
 #'
 #' # open parquet files from dataset
-#' ds <- arrow::open_dataset(file.path(tempdir(), "ds"))
+#' ds <- arrow::open_dataset(tf)
 #'
 #' # create a query. %>% also allowed
 #' q <- dplyr::filter(ds, group == 1)
@@ -451,13 +465,15 @@ read_sf_dataset <- function(dataset, find_geom = FALSE){
 #' nc_g <- dplyr::group_by(nc, group)
 #'
 #' # write out to parquet datasets
+#' tf <- tempfile()  # create temporary location
+#' on.exit(unlink(tf))
 #' # partitioning determined by dplyr 'group_vars'
-#' write_sf_dataset(nc_g, path = file.path(tempdir(), "ds"))
+#' write_sf_dataset(nc_g, path = tf)
 #'
-#' list.files(file.path(tempdir(), "ds"), recursive = TRUE)
+#' list.files(tf, recursive = TRUE)
 #'
 #' # open parquet files from dataset
-#' ds <- arrow::open_dataset(file.path(tempdir(), "ds"))
+#' ds <- arrow::open_dataset(tf)
 #'
 #' # create a query. %>% also allowed
 #' q <- dplyr::filter(ds, group == 1)

--- a/docs/404.html
+++ b/docs/404.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/articles/example_sfarrow.html
+++ b/docs/articles/example_sfarrow.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 
@@ -79,7 +79,7 @@
 
       
 
-      </header><script src="example_sfarrow_files/header-attrs-2.8/header-attrs.js"></script><div class="row">
+      </header><script src="example_sfarrow_files/header-attrs-2.10/header-attrs.js"></script><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
       <h1 data-toc-skip>Getting started examples</h1>
@@ -95,7 +95,8 @@
 <p><code>sfarrow</code> is designed to help read/write spatial vector data in “simple feature” format from/to Parquet files while maintaining coordinate reference system information. Essentially, this tool is attempting to connect <code>R</code> objects in <a href="https://r-spatial.github.io/sf/"><code>sf</code></a> and in <a href="https://arrow.apache.org/docs/r/"><code>arrow</code></a> and it relies on these packages for its internal work.</p>
 <p>A key goal is to support interoperability of spatial data in Parquet files. R objects (including <code>sf</code>) can be written to files with <code>arrow</code>; however, these do not necessarily maintain the spatial information or can be read in by Python. <code>sfarrow</code> implements a metadata format also used by Python <code>GeoPandas</code>, described here: <a href="https://github.com/geopandas/geo-arrow-spec">https://github.com/geopandas/geo-arrow-spec</a>. Note that these metadata are not stable yet, and <code>sfarrow</code> will warn you that it may change.</p>
 <div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span class="co"># install from devtools::install_github("wcjochem/sfarrow@main)</span>
+<code class="sourceCode R"><span class="co"># install from CRAN with install.packages('sfarrow')</span>
+<span class="co"># or install from devtools::install_github("wcjochem/sfarrow@main)</span>
 <span class="co"># load the library</span>
 <span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/wcjochem/sfarrow">sfarrow</a></span><span class="op">)</span>
 <span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="https://dplyr.tidyverse.org">dplyr</a></span>, warn.conflicts <span class="op">=</span> <span class="cn">FALSE</span><span class="op">)</span></code></pre></div>

--- a/docs/articles/example_sfarrow_files/header-attrs-2.10/header-attrs.js
+++ b/docs/articles/example_sfarrow_files/header-attrs-2.10/header-attrs.js
@@ -1,0 +1,12 @@
+// Pandoc 2.9 adds attributes on both header and div. We remove the former (to
+// be compatible with the behavior of Pandoc < 2.8).
+document.addEventListener('DOMContentLoaded', function(e) {
+  var hs = document.querySelectorAll("div.section[class*='level'] > :first-child");
+  var i, h, a;
+  for (i = 0; i < hs.length; i++) {
+    h = hs[i];
+    if (!/^h[1-6]$/i.test(h.tagName)) continue;  // it should be a header h1-h6
+    a = h.attributes;
+    while (a.length > 0) h.removeAttribute(a[0].name);
+  }
+});

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 
@@ -126,6 +126,14 @@
       <small>Source: <a href='https://github.com/wcjochem/sfarrow/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="sfarrow-041" class="section level1">
+<h1 class="page-header" data-toc-text="0.4.1">
+<a href="#sfarrow-041" class="anchor"></a>sfarrow 0.4.1<small> Unreleased </small>
+</h1>
+<ul>
+<li>Cleaning examples to remove reverse dependency check errors in <code>arrow</code> (reported by <a href='https://github.com/jonkeane'>@jonkeane</a>).</li>
+</ul>
+</div>
     <div id="sfarrow-040" class="section level1">
 <h1 class="page-header" data-toc-text="0.4.0">
 <a href="#sfarrow-040" class="anchor"></a>sfarrow 0.4.0<small> 2021-06-21 </small>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 1.6.1
 pkgdown_sha: ~
 articles:
   example_sfarrow: example_sfarrow.html
-last_built: 2021-06-25T15:20Z
+last_built: 2021-10-25T16:24Z
 

--- a/docs/reference/arrow_to_sf.html
+++ b/docs/reference/arrow_to_sf.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/reference/create_metadata.html
+++ b/docs/reference/create_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/reference/encode_wkb.html
+++ b/docs/reference/encode_wkb.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/reference/read_sf_dataset.html
+++ b/docs/reference/read_sf_dataset.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 
@@ -178,18 +178,20 @@ order to create <code><a href='https://r-spatial.github.io/sf/reference/sf.html'
 <span class='va'>nc_g</span> <span class='op'>&lt;-</span> <span class='fu'>dplyr</span><span class='fu'>::</span><span class='fu'><a href='https://dplyr.tidyverse.org/reference/group_by.html'>group_by</a></span><span class='op'>(</span><span class='va'>nc</span>, <span class='va'>group</span><span class='op'>)</span>
 
 <span class='co'># write out to parquet datasets</span>
+<span class='va'>tf</span> <span class='op'>&lt;-</span> <span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempfile</a></span><span class='op'>(</span><span class='op'>)</span>  <span class='co'># create temporary location</span>
+<span class='fu'><a href='https://rdrr.io/r/base/on.exit.html'>on.exit</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/unlink.html'>unlink</a></span><span class='op'>(</span><span class='va'>tf</span><span class='op'>)</span><span class='op'>)</span>
 <span class='co'># partitioning determined by dplyr 'group_vars'</span>
-<span class='fu'><a href='write_sf_dataset.html'>write_sf_dataset</a></span><span class='op'>(</span><span class='va'>nc_g</span>, path <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"ds"</span><span class='op'>)</span><span class='op'>)</span>
+<span class='fu'><a href='write_sf_dataset.html'>write_sf_dataset</a></span><span class='op'>(</span><span class='va'>nc_g</span>, path <span class='op'>=</span> <span class='va'>tf</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; <span class='warning'>Warning: This is an initial implementation of Parquet/Feather file support and</span>
 #&gt; <span class='warning'>geo metadata. This is tracking version 0.1.0 of the metadata</span>
 #&gt; <span class='warning'>(https://github.com/geopandas/geo-arrow-spec). This metadata</span>
 #&gt; <span class='warning'>specification may change and does not yet make stability promises.  We</span>
 #&gt; <span class='warning'>do not yet recommend using this in a production setting unless you are</span>
 #&gt; <span class='warning'>able to rewrite your Parquet/Feather files.</span></div><div class='input'>
-<span class='fu'><a href='https://rdrr.io/r/base/list.files.html'>list.files</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"ds"</span><span class='op'>)</span>, recursive <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
+<span class='fu'><a href='https://rdrr.io/r/base/list.files.html'>list.files</a></span><span class='op'>(</span><span class='va'>tf</span>, recursive <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; [1] "group=1/part-0.parquet" "group=2/part-1.parquet" "group=3/part-2.parquet"</div><div class='input'>
 <span class='co'># open parquet files from dataset</span>
-<span class='va'>ds</span> <span class='op'>&lt;-</span> <span class='fu'>arrow</span><span class='fu'>::</span><span class='fu'><a href='https://arrow.apache.org/docs/r//reference/open_dataset.html'>open_dataset</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"ds"</span><span class='op'>)</span><span class='op'>)</span>
+<span class='va'>ds</span> <span class='op'>&lt;-</span> <span class='fu'>arrow</span><span class='fu'>::</span><span class='fu'><a href='https://arrow.apache.org/docs/r//reference/open_dataset.html'>open_dataset</a></span><span class='op'>(</span><span class='va'>tf</span><span class='op'>)</span>
 
 <span class='co'># create a query. %&gt;% also allowed</span>
 <span class='va'>q</span> <span class='op'>&lt;-</span> <span class='fu'>dplyr</span><span class='fu'>::</span><span class='fu'><a href='https://dplyr.tidyverse.org/reference/filter.html'>filter</a></span><span class='op'>(</span><span class='va'>ds</span>, <span class='va'>group</span> <span class='op'>==</span> <span class='fl'>1</span><span class='op'>)</span>

--- a/docs/reference/sfarrow.html
+++ b/docs/reference/sfarrow.html
@@ -81,7 +81,7 @@ Python through the use of standardised metadata." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/reference/st_read_feather.html
+++ b/docs/reference/st_read_feather.html
@@ -73,7 +73,7 @@ identify geometry columns and coordinate reference system information." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/reference/st_read_parquet.html
+++ b/docs/reference/st_read_parquet.html
@@ -73,7 +73,7 @@ identify geometry columns and coordinate reference system information." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/reference/st_write_feather.html
+++ b/docs/reference/st_write_feather.html
@@ -74,7 +74,7 @@ columns (type sfc) are converted to well-known binary (WKB) format." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 
@@ -163,9 +163,15 @@ columns (type <code>sfc</code>) are converted to well-known binary (WKB) format.
     <div class='dont-index'><p><code><a href='https://arrow.apache.org/docs/r//reference/write_feather.html'>write_feather</a></code></p></div>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><div class='input'><span class='va'>nc</span> <span class='op'>&lt;-</span> <span class='fu'>sf</span><span class='fu'>::</span><span class='fu'><a href='https://r-spatial.github.io/sf/reference/st_read.html'>st_read</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/system.file.html'>system.file</a></span><span class='op'>(</span><span class='st'>"shape/nc.shp"</span>, package<span class='op'>=</span><span class='st'>"sf"</span><span class='op'>)</span>, quiet <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
+    <pre class="examples"><div class='input'><span class='co'># read spatial object</span>
+<span class='va'>nc</span> <span class='op'>&lt;-</span> <span class='fu'>sf</span><span class='fu'>::</span><span class='fu'><a href='https://r-spatial.github.io/sf/reference/st_read.html'>st_read</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/system.file.html'>system.file</a></span><span class='op'>(</span><span class='st'>"shape/nc.shp"</span>, package<span class='op'>=</span><span class='st'>"sf"</span><span class='op'>)</span>, quiet <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
 
-<span class='fu'>st_write_feather</span><span class='op'>(</span>obj<span class='op'>=</span><span class='va'>nc</span>, dsn<span class='op'>=</span><span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"nc.feather"</span><span class='op'>)</span><span class='op'>)</span>
+<span class='co'># create temp file</span>
+<span class='va'>tf</span> <span class='op'>&lt;-</span> <span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempfile</a></span><span class='op'>(</span>fileext <span class='op'>=</span> <span class='st'>'.feather'</span><span class='op'>)</span>
+<span class='fu'><a href='https://rdrr.io/r/base/on.exit.html'>on.exit</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/unlink.html'>unlink</a></span><span class='op'>(</span><span class='va'>tf</span><span class='op'>)</span><span class='op'>)</span>
+
+<span class='co'># write out object</span>
+<span class='fu'>st_write_feather</span><span class='op'>(</span>obj <span class='op'>=</span> <span class='va'>nc</span>, dsn <span class='op'>=</span> <span class='va'>tf</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; <span class='warning'>Warning: This is an initial implementation of Parquet/Feather file support and</span>
 #&gt; <span class='warning'>geo metadata. This is tracking version 0.1.0 of the metadata</span>
 #&gt; <span class='warning'>(https://github.com/geopandas/geo-arrow-spec). This metadata</span>
@@ -173,8 +179,8 @@ columns (type <code>sfc</code>) are converted to well-known binary (WKB) format.
 #&gt; <span class='warning'>do not yet recommend using this in a production setting unless you are</span>
 #&gt; <span class='warning'>able to rewrite your Parquet/Feather files.</span></div><div class='input'>
 <span class='co'># In Python, read the new file with geopandas.read_feather(...)</span>
-
-<span class='va'>nc_f</span> <span class='op'>&lt;-</span> <span class='fu'><a href='st_read_feather.html'>st_read_feather</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"nc.feather"</span><span class='op'>)</span><span class='op'>)</span>
+<span class='co'># read back into R</span>
+<span class='va'>nc_f</span> <span class='op'>&lt;-</span> <span class='fu'><a href='st_read_feather.html'>st_read_feather</a></span><span class='op'>(</span><span class='va'>tf</span><span class='op'>)</span>
 
 </div></pre>
   </div>

--- a/docs/reference/st_write_parquet.html
+++ b/docs/reference/st_write_parquet.html
@@ -74,7 +74,7 @@ columns (type sfc) are converted to well-known binary (WKB) format." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 
@@ -163,9 +163,15 @@ columns (type <code>sfc</code>) are converted to well-known binary (WKB) format.
     <div class='dont-index'><p><code><a href='https://arrow.apache.org/docs/r//reference/write_parquet.html'>write_parquet</a></code></p></div>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><div class='input'><span class='va'>nc</span> <span class='op'>&lt;-</span> <span class='fu'>sf</span><span class='fu'>::</span><span class='fu'><a href='https://r-spatial.github.io/sf/reference/st_read.html'>st_read</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/system.file.html'>system.file</a></span><span class='op'>(</span><span class='st'>"shape/nc.shp"</span>, package<span class='op'>=</span><span class='st'>"sf"</span><span class='op'>)</span>, quiet <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
+    <pre class="examples"><div class='input'><span class='co'># read spatial object</span>
+<span class='va'>nc</span> <span class='op'>&lt;-</span> <span class='fu'>sf</span><span class='fu'>::</span><span class='fu'><a href='https://r-spatial.github.io/sf/reference/st_read.html'>st_read</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/system.file.html'>system.file</a></span><span class='op'>(</span><span class='st'>"shape/nc.shp"</span>, package<span class='op'>=</span><span class='st'>"sf"</span><span class='op'>)</span>, quiet <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
 
-<span class='fu'>st_write_parquet</span><span class='op'>(</span>obj<span class='op'>=</span><span class='va'>nc</span>, dsn<span class='op'>=</span><span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"nc.parquet"</span><span class='op'>)</span><span class='op'>)</span>
+<span class='co'># create temp file</span>
+<span class='va'>tf</span> <span class='op'>&lt;-</span> <span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempfile</a></span><span class='op'>(</span>fileext <span class='op'>=</span> <span class='st'>'.parquet'</span><span class='op'>)</span>
+<span class='fu'><a href='https://rdrr.io/r/base/on.exit.html'>on.exit</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/unlink.html'>unlink</a></span><span class='op'>(</span><span class='va'>tf</span><span class='op'>)</span><span class='op'>)</span>
+
+<span class='co'># write out object</span>
+<span class='fu'>st_write_parquet</span><span class='op'>(</span>obj <span class='op'>=</span> <span class='va'>nc</span>, dsn <span class='op'>=</span> <span class='va'>tf</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; <span class='warning'>Warning: This is an initial implementation of Parquet/Feather file support and</span>
 #&gt; <span class='warning'>geo metadata. This is tracking version 0.1.0 of the metadata</span>
 #&gt; <span class='warning'>(https://github.com/geopandas/geo-arrow-spec). This metadata</span>
@@ -173,8 +179,8 @@ columns (type <code>sfc</code>) are converted to well-known binary (WKB) format.
 #&gt; <span class='warning'>do not yet recommend using this in a production setting unless you are</span>
 #&gt; <span class='warning'>able to rewrite your Parquet/Feather files.</span></div><div class='input'>
 <span class='co'># In Python, read the new file with geopandas.read_parquet(...)</span>
-
-<span class='va'>nc_p</span> <span class='op'>&lt;-</span> <span class='fu'><a href='st_read_parquet.html'>st_read_parquet</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"nc.parquet"</span><span class='op'>)</span><span class='op'>)</span>
+<span class='co'># read back into R</span>
+<span class='va'>nc_p</span> <span class='op'>&lt;-</span> <span class='fu'><a href='st_read_parquet.html'>st_read_parquet</a></span><span class='op'>(</span><span class='va'>tf</span><span class='op'>)</span>
 
 </div></pre>
   </div>

--- a/docs/reference/validate_metadata.html
+++ b/docs/reference/validate_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 

--- a/docs/reference/write_sf_dataset.html
+++ b/docs/reference/write_sf_dataset.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">sfarrow</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.4.1</span>
       </span>
     </div>
 
@@ -192,18 +192,20 @@ partitions.</p>
 <span class='va'>nc_g</span> <span class='op'>&lt;-</span> <span class='fu'>dplyr</span><span class='fu'>::</span><span class='fu'><a href='https://dplyr.tidyverse.org/reference/group_by.html'>group_by</a></span><span class='op'>(</span><span class='va'>nc</span>, <span class='va'>group</span><span class='op'>)</span>
 
 <span class='co'># write out to parquet datasets</span>
+<span class='va'>tf</span> <span class='op'>&lt;-</span> <span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempfile</a></span><span class='op'>(</span><span class='op'>)</span>  <span class='co'># create temporary location</span>
+<span class='fu'><a href='https://rdrr.io/r/base/on.exit.html'>on.exit</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/unlink.html'>unlink</a></span><span class='op'>(</span><span class='va'>tf</span><span class='op'>)</span><span class='op'>)</span>
 <span class='co'># partitioning determined by dplyr 'group_vars'</span>
-<span class='fu'>write_sf_dataset</span><span class='op'>(</span><span class='va'>nc_g</span>, path <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"ds"</span><span class='op'>)</span><span class='op'>)</span>
+<span class='fu'>write_sf_dataset</span><span class='op'>(</span><span class='va'>nc_g</span>, path <span class='op'>=</span> <span class='va'>tf</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; <span class='warning'>Warning: This is an initial implementation of Parquet/Feather file support and</span>
 #&gt; <span class='warning'>geo metadata. This is tracking version 0.1.0 of the metadata</span>
 #&gt; <span class='warning'>(https://github.com/geopandas/geo-arrow-spec). This metadata</span>
 #&gt; <span class='warning'>specification may change and does not yet make stability promises.  We</span>
 #&gt; <span class='warning'>do not yet recommend using this in a production setting unless you are</span>
 #&gt; <span class='warning'>able to rewrite your Parquet/Feather files.</span></div><div class='input'>
-<span class='fu'><a href='https://rdrr.io/r/base/list.files.html'>list.files</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"ds"</span><span class='op'>)</span>, recursive <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
+<span class='fu'><a href='https://rdrr.io/r/base/list.files.html'>list.files</a></span><span class='op'>(</span><span class='va'>tf</span>, recursive <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; [1] "group=1/part-0.parquet" "group=2/part-1.parquet" "group=3/part-2.parquet"</div><div class='input'>
 <span class='co'># open parquet files from dataset</span>
-<span class='va'>ds</span> <span class='op'>&lt;-</span> <span class='fu'>arrow</span><span class='fu'>::</span><span class='fu'><a href='https://arrow.apache.org/docs/r//reference/open_dataset.html'>open_dataset</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span><span class='op'>(</span><span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, <span class='st'>"ds"</span><span class='op'>)</span><span class='op'>)</span>
+<span class='va'>ds</span> <span class='op'>&lt;-</span> <span class='fu'>arrow</span><span class='fu'>::</span><span class='fu'><a href='https://arrow.apache.org/docs/r//reference/open_dataset.html'>open_dataset</a></span><span class='op'>(</span><span class='va'>tf</span><span class='op'>)</span>
 
 <span class='co'># create a query. %&gt;% also allowed</span>
 <span class='va'>q</span> <span class='op'>&lt;-</span> <span class='fu'>dplyr</span><span class='fu'>::</span><span class='fu'><a href='https://dplyr.tidyverse.org/reference/filter.html'>filter</a></span><span class='op'>(</span><span class='va'>ds</span>, <span class='va'>group</span> <span class='op'>==</span> <span class='fl'>1</span><span class='op'>)</span>

--- a/man/read_sf_dataset.Rd
+++ b/man/read_sf_dataset.Rd
@@ -41,13 +41,15 @@ nc$group <- sample(1:3, nrow(nc), replace = TRUE)
 nc_g <- dplyr::group_by(nc, group)
 
 # write out to parquet datasets
+tf <- tempfile()  # create temporary location
+on.exit(unlink(tf))
 # partitioning determined by dplyr 'group_vars'
-write_sf_dataset(nc_g, path = file.path(tempdir(), "ds"))
+write_sf_dataset(nc_g, path = tf)
 
-list.files(file.path(tempdir(), "ds"), recursive = TRUE)
+list.files(tf, recursive = TRUE)
 
 # open parquet files from dataset
-ds <- arrow::open_dataset(file.path(tempdir(), "ds"))
+ds <- arrow::open_dataset(tf)
 
 # create a query. \%>\% also allowed
 q <- dplyr::filter(ds, group == 1)

--- a/man/st_write_feather.Rd
+++ b/man/st_write_feather.Rd
@@ -22,13 +22,19 @@ write to a Feather file using \code{\link[arrow]{write_feather}}. Geometry
 columns (type \code{sfc}) are converted to well-known binary (WKB) format.
 }
 \examples{
+# read spatial object
 nc <- sf::st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
 
-st_write_feather(obj=nc, dsn=file.path(tempdir(), "nc.feather"))
+# create temp file
+tf <- tempfile(fileext = '.feather')
+on.exit(unlink(tf))
+
+# write out object
+st_write_feather(obj = nc, dsn = tf)
 
 # In Python, read the new file with geopandas.read_feather(...)
-
-nc_f <- st_read_feather(file.path(tempdir(), "nc.feather"))
+# read back into R
+nc_f <- st_read_feather(tf)
 
 }
 \seealso{

--- a/man/st_write_parquet.Rd
+++ b/man/st_write_parquet.Rd
@@ -22,13 +22,19 @@ write to a Parquet file using \code{\link[arrow]{write_parquet}}. Geometry
 columns (type \code{sfc}) are converted to well-known binary (WKB) format.
 }
 \examples{
+# read spatial object
 nc <- sf::st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
 
-st_write_parquet(obj=nc, dsn=file.path(tempdir(), "nc.parquet"))
+# create temp file
+tf <- tempfile(fileext = '.parquet')
+on.exit(unlink(tf))
+
+# write out object
+st_write_parquet(obj = nc, dsn = tf)
 
 # In Python, read the new file with geopandas.read_parquet(...)
-
-nc_p <- st_read_parquet(file.path(tempdir(), "nc.parquet"))
+# read back into R
+nc_p <- st_read_parquet(tf)
 
 }
 \seealso{

--- a/man/write_sf_dataset.Rd
+++ b/man/write_sf_dataset.Rd
@@ -49,13 +49,15 @@ nc$group <- sample(1:3, nrow(nc), replace = TRUE)
 nc_g <- dplyr::group_by(nc, group)
 
 # write out to parquet datasets
+tf <- tempfile()  # create temporary location
+on.exit(unlink(tf))
 # partitioning determined by dplyr 'group_vars'
-write_sf_dataset(nc_g, path = file.path(tempdir(), "ds"))
+write_sf_dataset(nc_g, path = tf)
 
-list.files(file.path(tempdir(), "ds"), recursive = TRUE)
+list.files(tf, recursive = TRUE)
 
 # open parquet files from dataset
-ds <- arrow::open_dataset(file.path(tempdir(), "ds"))
+ds <- arrow::open_dataset(tf)
 
 # create a query. \%>\% also allowed
 q <- dplyr::filter(ds, group == 1)

--- a/vignettes/example_sfarrow.Rmd
+++ b/vignettes/example_sfarrow.Rmd
@@ -32,7 +32,8 @@ Note that these metadata are not stable yet, and `sfarrow` will warn you that it
 may change.
 
 ```{r setup}
-# install from devtools::install_github("wcjochem/sfarrow@main)
+# install from CRAN with install.packages('sfarrow')
+# or install from devtools::install_github("wcjochem/sfarrow@main)
 # load the library
 library(sfarrow)
 library(dplyr, warn.conflicts = FALSE)


### PR DESCRIPTION
Reported in #11: the files created in the writing examples remained the tempdir and caused issues for some checks.
Following the model used in `arrow` suggested by @jonkeane, a `tempfile()` is now created and should be removed on exiting.
